### PR TITLE
Add basic CLI

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,0 +1,13 @@
+"use strict";
+
+// lalala
+[4, 9, 16].map(Math.sqrt);  // → [ 2, 3, 4 ]
+const sth = function () { return "lalala" === 1; };  // asd
+sth();  // eslint-disable-line no-unused-expressions
+// → false
+/* eslint-disable no-unused-expressions */
+"test str";
+"test";  // → 'test'
+/* eslint-enable no-unused-expressions */
+const time = 3 * 15;  // eslint-disable-line no-unused-vars
+// endcomm

--- a/index.js
+++ b/index.js
@@ -1,46 +1,32 @@
 "use strict";
 
 const connoisseur = require("./lib/connoisseur");
+const fs = require("fs");
+const sourceFiles = require("yargs").argv._;
 
-const CODE = `
-"use strict";
+const displayErrors = function (errors) {
+    let hasError = false;
+    errors.forEach(file => {
+        if (!file[1].length)
+            return;
 
-// lalala
-[4, 9, 16].map(Math.sqrt);  // → [ 2, 3, 4 ]
-const sth = function () { return "lalala" === 1; };  // asd
-sth();  // eslint-disable-line no-unused-expressions
-// → false
-/* eslint-disable no-unused-expressions */
-"test str";
-"test";  // → 'test'
-/* eslint-enable no-unused-expressions */
-const time = 3 * 15;  // eslint-disable-line no-unused-vars
-// endcomm
-`;
-
-const result = connoisseur(CODE, "stdin");
-
-const exitCode = result.reduce((code, piece) => {
-    /* eslint-disable no-console */
-    let returnCode;
-
-    if (piece.error) {
-        returnCode = 2;
+        hasError = true;
+        /* eslint-disable no-console */
         console.log(
-            "Error: \n",
-            piece,
-            piece.error.stack
-                .split("\n")
-                .slice(0, 2)
-                .join("\n")
+            `Errors found for file ${file[0]}:\n${
+                file[1].reduce((prev, errorData) =>
+                    `${prev}\t${errorData.code.replace(/(\r\n|\n|\r)/gm, "\r\n\t")}\t${
+                        errorData.error || `→ Expected: ${errorData.expected}, Found: ${errorData.actual}`
+                    }\n`
+                , "")
+            }`
         );
-    } else {
-        returnCode = 1;
-        console.log("Failed: \n", piece);
-    }
+        /* eslint-enable no-console */
+    });
 
-    return Math.max(returnCode, code);
-    /* eslint-enable no-console */
-});
+    return hasError;
+};
 
-process.exit(exitCode);
+const errors = sourceFiles.map(filepath => [filepath, connoisseur(fs.readFileSync(filepath, "utf8"))]);
+
+process.exit(displayErrors(errors));

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "test": "istanbul cover ./node_modules/mocha/bin/_mocha",
     "coveralls": "cat ./coverage/lcov.info | coveralls"
   },
+  "bin": {
+    "connoisseur": "./index.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/BYK/connoisseur.git"


### PR DESCRIPTION
With this patch, connoisseur can:
- run on single or multiple source files (given as CL arguments)
- print file based error reports
